### PR TITLE
Fix README newline and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CKA-excercises
+# CKA-exercises
 
 Let's practice [CKA](https://training.linuxfoundation.org/certification/certified-kubernetes-administrator-cka/) questions.
 


### PR DESCRIPTION
## Summary
- correct 'CKA-excercises' typo in README
- ensure README ends with a newline

## Testing
- `cat -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_6843ba93b66083228c88340ec6a0a078